### PR TITLE
FIx typo in 08_joins.ipynb

### DIFF
--- a/08_joins.ipynb
+++ b/08_joins.ipynb
@@ -127,7 +127,7 @@
     "* a single `Symbol` or string if joining on one column with the same name, e.g. `on=:id`\n",
     "* a `Pair` of `Symbol`s or string if joining on one column with different names, e.g. `on=:id=>:id2`\n",
     "* a vector of `Symbol`s or strings if joining on multiple columns with the same name, e.g. `on=[:id1, :id2]`\n",
-    "* a vector of `Pair`s of `Symbol`s or strings if joining on multiple columns with the same name, e.g. `on=[:a1=>:a2, :b1=>:b2]`\n",
+    "* a vector of `Pair`s of `Symbol`s or strings if joining on multiple columns with different names, e.g. `on=[:a1=>:a2, :b1=>:b2]`\n",
     "* a vector containing a combination of `Symbol`s or strings or `Pair` of `Symbol`s or strings, e.g. `on=[:a1=>:a2, :b1]`"
    ]
   },


### PR DESCRIPTION
The line above is for multiple columns, same names.

I think the current line is about multiple columns, different names.